### PR TITLE
(Fabric) Use correct player when respawning

### DIFF
--- a/fabric/src/main/java/org/popcraft/chunkyborder/bridge/RespawningPlayerBridge.java
+++ b/fabric/src/main/java/org/popcraft/chunkyborder/bridge/RespawningPlayerBridge.java
@@ -1,0 +1,9 @@
+package org.popcraft.chunkyborder.bridge;
+
+import net.minecraft.server.network.ServerPlayerEntity;
+
+public interface RespawningPlayerBridge {
+
+    void chunkyborder$setRespawningPlayer(ServerPlayerEntity player);
+
+}

--- a/fabric/src/main/java/org/popcraft/chunkyborder/mixin/PlayerManagerMixin.java
+++ b/fabric/src/main/java/org/popcraft/chunkyborder/mixin/PlayerManagerMixin.java
@@ -1,0 +1,32 @@
+package org.popcraft.chunkyborder.mixin;
+
+import net.minecraft.server.PlayerManager;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.WorldProperties;
+import org.popcraft.chunkyborder.bridge.RespawningPlayerBridge;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+
+import java.util.Optional;
+
+@Mixin(PlayerManager.class)
+public class PlayerManagerMixin {
+
+    @Inject(
+            method = "respawnPlayer",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/server/network/ServerPlayNetworkHandler;requestTeleport(DDDFF)V",
+                    shift = At.Shift.BEFORE
+            ),
+            locals = LocalCapture.CAPTURE_FAILHARD
+    )
+    private void handleRespawningPlayerBridge(ServerPlayerEntity player, boolean alive, CallbackInfoReturnable<ServerPlayerEntity> cir, BlockPos blockPos, float f, boolean bl, ServerWorld serverWorld, Optional optional, ServerWorld serverWorld2, ServerPlayerEntity respawningPlayer) {
+        ((RespawningPlayerBridge) respawningPlayer.networkHandler).chunkyborder$setRespawningPlayer(respawningPlayer);
+    }
+}

--- a/fabric/src/main/resources/chunkyborder.mixins.json
+++ b/fabric/src/main/resources/chunkyborder.mixins.json
@@ -4,6 +4,7 @@
   "package": "org.popcraft.chunkyborder.mixin",
   "compatibilityLevel": "JAVA_8",
   "mixins": [
+    "PlayerManagerMixin",
     "ServerPlayNetworkHandlerMixin"
   ],
   "client": [


### PR DESCRIPTION
This fixes a bug preventing players from respawning at their respawn position if that respawn position is outside the previous world the player was in.

For example, if the player dies in the nether, and the nether has a border set to 1000, if the player's respawn position is above 1000, even if it's inside the respawning world's border, then it'll prevent the player from respawning there. This PR fixes that behavior.