### PR TITLE
Fix compatibility with ServerReplay

### DIFF
--- a/bukkit/src/main/java/org/popcraft/chunkyborder/ChunkyBorderBukkit.java
+++ b/bukkit/src/main/java/org/popcraft/chunkyborder/ChunkyBorderBukkit.java
@@ -41,7 +41,11 @@ import org.popcraft.chunkyborder.integration.Pl3xMapIntegration;
 import org.popcraft.chunkyborder.integration.SquaremapIntegration;
 import org.popcraft.chunkyborder.platform.Config;
 import org.popcraft.chunkyborder.platform.MapIntegrationLoader;
-import org.popcraft.chunkyborder.util.*;
+import org.popcraft.chunkyborder.util.BorderColor;
+import org.popcraft.chunkyborder.util.ClientBorder;
+import org.popcraft.chunkyborder.util.Particles;
+import org.popcraft.chunkyborder.util.PluginMessage;
+import org.popcraft.chunkyborder.util.EnumUtil;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;

--- a/bukkit/src/main/java/org/popcraft/chunkyborder/ChunkyBorderBukkit.java
+++ b/bukkit/src/main/java/org/popcraft/chunkyborder/ChunkyBorderBukkit.java
@@ -41,10 +41,7 @@ import org.popcraft.chunkyborder.integration.Pl3xMapIntegration;
 import org.popcraft.chunkyborder.integration.SquaremapIntegration;
 import org.popcraft.chunkyborder.platform.Config;
 import org.popcraft.chunkyborder.platform.MapIntegrationLoader;
-import org.popcraft.chunkyborder.util.BorderColor;
-import org.popcraft.chunkyborder.util.Particles;
-import org.popcraft.chunkyborder.util.PluginMessage;
-import org.popcraft.chunkyborder.util.EnumUtil;
+import org.popcraft.chunkyborder.util.*;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
@@ -302,7 +299,7 @@ public final class ChunkyBorderBukkit extends JavaPlugin implements Listener {
     }
 
     private void sendBorderPacket(final Collection<? extends org.bukkit.entity.Player> players, final World world, final Shape shape) {
-        final byte[] data = PluginMessage.writeBorder(world, shape);
+        final byte[] data = PluginMessage.writeBorder(new ClientBorder(world.getKey(), shape));
         for (final org.bukkit.entity.Player player : players) {
             player.sendPluginMessage(this, PLAY_BORDER_PACKET_ID, data);
         }

--- a/common/src/main/java/org/popcraft/chunkyborder/util/ClientBorder.java
+++ b/common/src/main/java/org/popcraft/chunkyborder/util/ClientBorder.java
@@ -1,6 +1,38 @@
 package org.popcraft.chunkyborder.util;
 
+import org.popcraft.chunky.platform.util.Vector2;
+import org.popcraft.chunky.shape.AbstractEllipse;
+import org.popcraft.chunky.shape.AbstractPolygon;
+import org.popcraft.chunky.shape.Shape;
 import org.popcraft.chunkyborder.shape.BorderShape;
+import org.popcraft.chunkyborder.shape.EllipseBorderShape;
+import org.popcraft.chunkyborder.shape.PolygonBorderShape;
+
+import java.util.List;
 
 public record ClientBorder(String worldKey, BorderShape borderShape) {
+    public ClientBorder(final String worldKey, final Shape shape) {
+        this(worldKey, convertShapeToBorderShape(shape));
+    }
+
+    private static BorderShape convertShapeToBorderShape(final Shape shape) {
+        if (shape instanceof final AbstractPolygon polygon) {
+            final List<Vector2> points = polygon.points();
+            final int numPoints = points.size();
+            final double[] pointsX = new double[numPoints];
+            final double[] pointsZ = new double[numPoints];
+            for (int i = 0; i < numPoints; i++) {
+                final Vector2 point = points.get(i);
+                pointsX[i] = point.getX();
+                pointsZ[i] = point.getZ();
+            }
+            return new PolygonBorderShape(pointsX, pointsZ);
+        }
+        if (shape instanceof final AbstractEllipse ellipse) {
+            final Vector2 center = ellipse.center();
+            final Vector2 radii = ellipse.radii();
+            return new EllipseBorderShape(center.getX(), center.getZ(), radii.getX(), radii.getZ());
+        }
+        return null;
+    }
 }

--- a/fabric/src/main/java/org/popcraft/chunkyborder/packet/BorderPayload.java
+++ b/fabric/src/main/java/org/popcraft/chunkyborder/packet/BorderPayload.java
@@ -11,13 +11,10 @@ import org.popcraft.chunkyborder.util.PluginMessage;
 
 public class BorderPayload implements CustomPayload {
     public static final CustomPayload.Id<BorderPayload> ID = new CustomPayload.Id<>(Identifier.of("chunky:border"));
-    private World world;
-    private Shape shape;
-    private ClientBorder border;
+    private final ClientBorder border;
 
     public BorderPayload(final World world, final Shape shape) {
-        this.world = world;
-        this.shape = shape;
+        this.border = new ClientBorder(world.getKey(), shape);
     }
 
     public BorderPayload(final PacketByteBuf buf) {
@@ -28,7 +25,7 @@ public class BorderPayload implements CustomPayload {
     }
 
     public void write(final PacketByteBuf buf) {
-        buf.writeBytes(PluginMessage.writeBorder(world, shape));
+        buf.writeBytes(PluginMessage.writeBorder(this.border));
     }
 
     public ClientBorder getBorder() {

--- a/forge/src/main/java/org/popcraft/chunkyborder/packet/BorderPayload.java
+++ b/forge/src/main/java/org/popcraft/chunkyborder/packet/BorderPayload.java
@@ -11,13 +11,10 @@ import org.popcraft.chunkyborder.util.PluginMessage;
 
 public class BorderPayload implements CustomPacketPayload {
     public static final Type<BorderPayload> ID = CustomPacketPayload.createType("chunky:border");
-    private World world;
-    private Shape shape;
-    private ClientBorder border;
+    private final ClientBorder border;
 
     public BorderPayload(final World world, final Shape shape) {
-        this.world = world;
-        this.shape = shape;
+        this.border = new ClientBorder(world.getKey(), shape);
     }
 
     public BorderPayload(final FriendlyByteBuf buf) {
@@ -28,7 +25,7 @@ public class BorderPayload implements CustomPacketPayload {
     }
 
     public void write(final FriendlyByteBuf buf) {
-        buf.writeBytes(PluginMessage.writeBorder(world, shape));
+        buf.writeBytes(PluginMessage.writeBorder(this.border));
     }
 
     public ClientBorder getBorder() {

--- a/neoforge/src/main/java/org/popcraft/chunkyborder/packet/BorderPayload.java
+++ b/neoforge/src/main/java/org/popcraft/chunkyborder/packet/BorderPayload.java
@@ -12,13 +12,10 @@ import org.popcraft.chunkyborder.util.PluginMessage;
 
 public class BorderPayload implements CustomPacketPayload {
     public static final CustomPacketPayload.Type<BorderPayload> ID = new CustomPacketPayload.Type<>(ResourceLocation.parse("chunky:border"));
-    private World world;
-    private Shape shape;
-    private ClientBorder border;
+    private final ClientBorder border;
 
     public BorderPayload(final World world, final Shape shape) {
-        this.world = world;
-        this.shape = shape;
+        this.border = new ClientBorder(world.getKey(), shape);
     }
 
     public BorderPayload(final FriendlyByteBuf buf) {
@@ -29,7 +26,7 @@ public class BorderPayload implements CustomPacketPayload {
     }
 
     public void write(final FriendlyByteBuf buf) {
-        buf.writeBytes(PluginMessage.writeBorder(world, shape));
+        buf.writeBytes(PluginMessage.writeBorder(this.border));
     }
 
     public ClientBorder getBorder() {


### PR DESCRIPTION
Fixes an issue that ServerReplay has with BorderPayloads causing `NullPointerExceptions`, since BorderPayloads were never intended to be read in then written back out. This PR fixes this by removing the 2 possible states the payload can be in and merging them into one.

The user that reported the bug confirmed that this fixes the issue.