### PR TITLE
Prevent block breaks outside the border

### DIFF
--- a/bukkit/src/main/java/org/popcraft/chunkyborder/ChunkyBorderBukkit.java
+++ b/bukkit/src/main/java/org/popcraft/chunkyborder/ChunkyBorderBukkit.java
@@ -29,6 +29,7 @@ import org.popcraft.chunky.util.TranslationKey;
 import org.popcraft.chunky.util.Translator;
 import org.popcraft.chunkyborder.command.BorderCommand;
 import org.popcraft.chunkyborder.event.border.BorderChangeEvent;
+import org.popcraft.chunkyborder.event.server.BlockBreakEvent;
 import org.popcraft.chunkyborder.event.server.BlockPlaceEvent;
 import org.popcraft.chunkyborder.event.server.CreatureSpawnEvent;
 import org.popcraft.chunkyborder.event.server.PlayerQuitEvent;
@@ -278,6 +279,17 @@ public final class ChunkyBorderBukkit extends JavaPlugin implements Listener {
         final BlockPlaceEvent blockPlaceEvent = new BlockPlaceEvent(player, location);
         chunkyBorder.getChunky().getEventBus().call(blockPlaceEvent);
         if (blockPlaceEvent.isCancelled()) {
+            e.setCancelled(true);
+        }
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
+    public void onBlockBreak(final org.bukkit.event.block.BlockBreakEvent e) {
+        final org.bukkit.Location bukkitLocation = e.getBlock().getLocation();
+        final World world = new BukkitWorld(e.getPlayer().getWorld());
+        final BlockBreakEvent blockBreakEvent = new BlockBreakEvent(new BukkitPlayer(e.getPlayer()), new Location(world, bukkitLocation.getX(), bukkitLocation.getY(), bukkitLocation.getZ()));
+        chunkyBorder.getChunky().getEventBus().call(blockBreakEvent);
+        if (blockBreakEvent.isCancelled()) {
             e.setCancelled(true);
         }
     }

--- a/bukkit/src/main/resources/plugin.yml
+++ b/bukkit/src/main/resources/plugin.yml
@@ -16,3 +16,6 @@ permissions:
   chunkyborder.bypass.place:
     description: Bypass border block placement checks
     default: false
+  chunkyborder.bypass.break:
+    description: Bypass border block breaking checks
+    default: false

--- a/common/src/main/java/org/popcraft/chunkyborder/ChunkyBorder.java
+++ b/common/src/main/java/org/popcraft/chunkyborder/ChunkyBorder.java
@@ -21,6 +21,7 @@ import org.popcraft.chunky.util.TranslationKey;
 import org.popcraft.chunky.util.Translator;
 import org.popcraft.chunky.util.Version;
 import org.popcraft.chunkyborder.event.border.BorderChangeEvent;
+import org.popcraft.chunkyborder.event.server.BlockBreakEvent;
 import org.popcraft.chunkyborder.event.server.BlockPlaceEvent;
 import org.popcraft.chunkyborder.event.server.CreatureSpawnEvent;
 import org.popcraft.chunkyborder.event.server.PlayerQuitEvent;
@@ -162,6 +163,17 @@ public class ChunkyBorder {
                         final double x = ((int) location.getX()) + 0.5;
                         final double z = ((int) location.getZ()) + 0.5;
                         return !border.isBounding(x, z) && !e.getPlayer().hasPermission("chunkyborder.bypass.place");
+                    })
+                    .orElse(false));
+        });
+        eventBus.subscribe(BlockBreakEvent.class, e -> {
+            final Location location = e.getLocation();
+            e.setCancelled(getBorder(location.getWorld().getName())
+                    .map(BorderData::getBorder)
+                    .map(border -> {
+                        final double x = ((int) location.getX()) + 0.5;
+                        final double z = ((int) location.getZ()) + 0.5;
+                        return !border.isBounding(x, z) && !e.getPlayer().hasPermission("chunkyborder.bypass.break");
                     })
                     .orElse(false));
         });

--- a/common/src/main/java/org/popcraft/chunkyborder/event/server/BlockBreakEvent.java
+++ b/common/src/main/java/org/popcraft/chunkyborder/event/server/BlockBreakEvent.java
@@ -1,0 +1,23 @@
+package org.popcraft.chunkyborder.event.server;
+
+import org.popcraft.chunky.event.Cancellable;
+import org.popcraft.chunky.platform.Player;
+import org.popcraft.chunky.platform.util.Location;
+
+public class BlockBreakEvent extends Cancellable {
+    private final Player player;
+    private final Location location;
+
+    public BlockBreakEvent(final Player player, final Location location) {
+        this.player = player;
+        this.location = location;
+    }
+
+    public Player getPlayer() {
+        return player;
+    }
+
+    public Location getLocation() {
+        return location;
+    }
+}

--- a/forge/src/main/java/org/popcraft/chunkyborder/ChunkyBorderForge.java
+++ b/forge/src/main/java/org/popcraft/chunkyborder/ChunkyBorderForge.java
@@ -12,6 +12,7 @@ import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.event.entity.EntityJoinLevelEvent;
+import net.minecraftforge.event.level.BlockEvent;
 import net.minecraftforge.event.server.ServerStartedEvent;
 import net.minecraftforge.event.server.ServerStoppingEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
@@ -26,11 +27,14 @@ import org.popcraft.chunky.platform.ForgePlayer;
 import org.popcraft.chunky.platform.ForgeWorld;
 import org.popcraft.chunky.platform.Player;
 import org.popcraft.chunky.platform.World;
+import org.popcraft.chunky.platform.util.Location;
 import org.popcraft.chunky.platform.util.Vector3;
 import org.popcraft.chunky.shape.Shape;
 import org.popcraft.chunky.util.Translator;
 import org.popcraft.chunkyborder.command.BorderCommand;
 import org.popcraft.chunkyborder.event.border.BorderChangeEvent;
+import org.popcraft.chunkyborder.event.server.BlockBreakEvent;
+import org.popcraft.chunkyborder.event.server.BlockPlaceEvent;
 import org.popcraft.chunkyborder.integration.DynmapCommonAPIProvider;
 import org.popcraft.chunkyborder.packet.BorderPayload;
 import org.popcraft.chunkyborder.platform.Config;
@@ -160,6 +164,32 @@ public class ChunkyBorderForge {
                 }
             }
         });
+    }
+
+    @SubscribeEvent
+    public void onBlockPlace(final BlockEvent.EntityPlaceEvent event) {
+        if (!(event.getEntity() instanceof ServerPlayer player)) {
+            return;
+        }
+
+        final BlockPlaceEvent placeEvent = new BlockPlaceEvent(new ForgePlayer(player), new Location(new ForgeWorld((ServerLevel) event.getLevel()), event.getPos().getX(), event.getPos().getY(), event.getPos().getZ()));
+        chunkyBorder.getChunky().getEventBus().call(placeEvent);
+        if (placeEvent.isCancelled()) {
+            event.setCanceled(true);
+        }
+    }
+
+    @SubscribeEvent
+    public void onBlockBreak(final BlockEvent.BreakEvent event) {
+        if (!(event.getPlayer() instanceof ServerPlayer player)) {
+            return;
+        }
+
+        final BlockBreakEvent breakEvent = new BlockBreakEvent(new ForgePlayer(player), new Location(new ForgeWorld((ServerLevel) event.getLevel()), event.getPos().getX(), event.getPos().getY(), event.getPos().getZ()));
+        chunkyBorder.getChunky().getEventBus().call(breakEvent);
+        if (breakEvent.isCancelled()) {
+            event.setCanceled(true);
+        }
     }
 
     private void sendBorderPacket(final Collection<ServerPlayer> players, final World world, final Shape shape) {

--- a/neoforge/src/main/java/org/popcraft/chunkyborder/ChunkyBorderNeoForge.java
+++ b/neoforge/src/main/java/org/popcraft/chunkyborder/ChunkyBorderNeoForge.java
@@ -14,6 +14,7 @@ import net.neoforged.fml.common.Mod;
 import net.neoforged.fml.loading.FMLPaths;
 import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.event.entity.EntityJoinLevelEvent;
+import net.neoforged.neoforge.event.level.BlockEvent;
 import net.neoforged.neoforge.event.server.ServerStartedEvent;
 import net.neoforged.neoforge.event.server.ServerStoppingEvent;
 import net.neoforged.neoforge.event.tick.ServerTickEvent;
@@ -24,11 +25,14 @@ import org.popcraft.chunky.platform.NeoForgePlayer;
 import org.popcraft.chunky.platform.NeoForgeWorld;
 import org.popcraft.chunky.platform.Player;
 import org.popcraft.chunky.platform.World;
+import org.popcraft.chunky.platform.util.Location;
 import org.popcraft.chunky.platform.util.Vector3;
 import org.popcraft.chunky.shape.Shape;
 import org.popcraft.chunky.util.Translator;
 import org.popcraft.chunkyborder.command.BorderCommand;
 import org.popcraft.chunkyborder.event.border.BorderChangeEvent;
+import org.popcraft.chunkyborder.event.server.BlockBreakEvent;
+import org.popcraft.chunkyborder.event.server.BlockPlaceEvent;
 import org.popcraft.chunkyborder.integration.DynmapCommonAPIProvider;
 import org.popcraft.chunkyborder.packet.BorderPayload;
 import org.popcraft.chunkyborder.platform.Config;
@@ -153,6 +157,32 @@ public class ChunkyBorderNeoForge {
                 }
             }
         });
+    }
+
+    @SubscribeEvent
+    public void onBlockPlace(final BlockEvent.EntityPlaceEvent event) {
+        if (!(event.getEntity() instanceof ServerPlayer player)) {
+            return;
+        }
+
+        final BlockPlaceEvent placeEvent = new BlockPlaceEvent(new NeoForgePlayer(player), new Location(new NeoForgeWorld((ServerLevel) event.getLevel()), event.getPos().getX(), event.getPos().getY(), event.getPos().getZ()));
+        chunkyBorder.getChunky().getEventBus().call(placeEvent);
+        if (placeEvent.isCancelled()) {
+            event.setCanceled(true);
+        }
+    }
+
+    @SubscribeEvent
+    public void onBlockBreak(final BlockEvent.BreakEvent event) {
+        if (!(event.getPlayer() instanceof ServerPlayer player)) {
+            return;
+        }
+
+        final BlockBreakEvent breakEvent = new BlockBreakEvent(new NeoForgePlayer(player), new Location(new NeoForgeWorld((ServerLevel) event.getLevel()), event.getPos().getX(), event.getPos().getY(), event.getPos().getZ()));
+        chunkyBorder.getChunky().getEventBus().call(breakEvent);
+        if (breakEvent.isCancelled()) {
+            event.setCanceled(true);
+        }
     }
 
     private void sendBorderPacket(final Collection<ServerPlayer> players, final World world, final Shape shape) {


### PR DESCRIPTION
Closes #87 

Adds a block break event and implements it on all platforms, tested it on bukkit but not the others.

I noticed that other platforms were missing the place event so I added it to (neo)forge, couldn't find a simple way to implement it on fabric.